### PR TITLE
Fixes unknown datasource when first loading dashboard

### DIFF
--- a/grafana/datasources/Prometheus.json
+++ b/grafana/datasources/Prometheus.json
@@ -1,5 +1,5 @@
 {
-    "name":"Prometheus",
+    "name":"prometheus",
     "type":"prometheus",
     "url":"http://prometheus:9090",
     "access":"proxy",


### PR DESCRIPTION
The dashboard is looking for an all lower-case datasource name. 

Without this change, I get an error saying it can't find the datasource 'prometheus' when first loading the dashboard. The dashboard config json also references the lower-case version, and updating the json config to upper-P does nothing.